### PR TITLE
added preload type to the "withCustomAudio" addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ReactDOM.render(
 
 ### Custom Audio Example
 
-It is also easy to built players **without** using SoundCloud API. You just need to pass audio source via `streamUrl` and all other necessary track meta information can be passed as custom props.
+It is also easy to built players **without** using SoundCloud API. You just need to pass audio source via `streamUrl` and all other necessary track meta information can be passed as custom props. Also you can choose `preloadType`, according to [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#Attributes), by default this property equal to 'auto'.
 
 ```js
 import React from 'react';
@@ -101,7 +101,8 @@ class App extends React.Component {
     return (
       <AWSSoundPlayer
         streamUrl={streamUrl}
-        trackTitle={trackTitle} />
+        trackTitle={trackTitle} 
+        preloadType='auto' />
     );
   }
 }

--- a/examples/app.js
+++ b/examples/app.js
@@ -473,6 +473,7 @@ class CustomAudioExample extends React.Component {
         <AWSSoundPlayer
           streamUrl={awsKsmtkStreamUrl}
           trackTitle={awsKsmtkTrackTitle}
+          preloadType="metadata"
           {...this.props} />
         <div className="mt2">
           <pre><code className="javascript">{`import React from 'react';
@@ -504,7 +505,8 @@ class App extends React.Component {
     return (
       <AWSSoundPlayer
         streamUrl={streamUrl}
-        trackTitle={trackTitle} />
+        trackTitle={trackTitle}
+        preloadType="metadata" />
     );
   }
 }

--- a/examples/players/AWSSoundPlayer.js
+++ b/examples/players/AWSSoundPlayer.js
@@ -20,8 +20,13 @@ class AWSSoundPlayer extends Component {
 }
 
 AWSSoundPlayer.propTypes = {
+  preloadType: PropTypes.string,
   streamUrl: PropTypes.string.isRequired,
   trackTitle: PropTypes.string.isRequired
+};
+
+AWSSoundPlayer.defaultProps = {
+  preloadType: 'auto'
 };
 
 export default withCustomAudio(AWSSoundPlayer);

--- a/src/addons/withSoundCloudAudio.js
+++ b/src/addons/withSoundCloudAudio.js
@@ -54,10 +54,10 @@ export default function withSoundCloudAudio (WrappedComponent) {
 
     requestAudio() {
       const { soundCloudAudio } = this;
-      const { resolveUrl, streamUrl, onReady } = this.props;
+      const { resolveUrl, streamUrl, onReady, preloadType = 'auto' } = this.props;
 
       if (streamUrl) {
-        soundCloudAudio.preload(streamUrl);
+        soundCloudAudio.preload(streamUrl, preloadType);
       } else if (resolveUrl) {
         soundCloudAudio.resolve(resolveUrl, (data) => {
           if (!this.mounted) {


### PR DESCRIPTION
Hello! I use react-soundplayer to play custom audio files and I wish to add possibility change audio preloader type ('none', 'auto', 'metadata') according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#Attributes

I've already send pull request to the [soundcloud-audio.js](https://github.com/voronianski/soundcloud-audio.js) and asking them to add possibility change preloader type [https://github.com/voronianski/soundcloud-audio.js/pull/21](https://github.com/voronianski/soundcloud-audio.js/pull/21). If they agree, it would be great to add this changes to react-soundplayer.