### PR TITLE
pause player on unmount

### DIFF
--- a/src/components/PlayButton.js
+++ b/src/components/PlayButton.js
@@ -13,6 +13,13 @@ class PlayButton extends Component {
     );
   }
 
+  componentWillUnmount() {
+    const { playing, soundCloudAudio } = this.props;
+    if (playing && soundCloudAudio) {
+      soundCloudAudio.pause();
+    }
+  }
+
   handleClick(e) {
     const { playing, soundCloudAudio, onTogglePlay } = this.props;
 


### PR DESCRIPTION
The `PlayButton` currently just leaves the underlying audio object playing when its unmounted. I believe it should pause `soundCloudAudio` when its about to be unmounted because the underlying audio object will just keep on playing even though the `PlayButton` instance that started it is no longer being rendered in the UI. 

Scenarios where this could be an issue is when using a router like React-Router and playing a player on one page and "navigating" away from it will cause the player to keep on playing even though the player is no longer being rendered.

This should fix #76 and #74.